### PR TITLE
Prefill query param

### DIFF
--- a/src/FormWizard.js
+++ b/src/FormWizard.js
@@ -66,8 +66,8 @@ class FormWizard extends Component {
               ...this.state.formData,
               [prefiller[i].key]:
                 elem.type === "number"
-                  ? parseInt(prefiller[i].val)
-                  : prefiller[i].val
+                  ? parseInt(prefiller[i].val, prefiller[i].val)
+                  : decodeURI(prefiller[i].val)
             }
           });
         }

--- a/src/FormWizard.js
+++ b/src/FormWizard.js
@@ -134,7 +134,7 @@ class FormWizard extends Component {
     // Enable prefilling of input text fields by passing url query param from initial step to session storage
 
     const queryParamsRaw = window.location.search;
-    let queryParamsCleaned = queryParamsRaw.replaceAll("?", "");
+    let queryParamsCleaned = queryParamsRaw.replace("?", "");
     if (queryParamsCleaned.startsWith("prefill")) {
       queryParamsCleaned = queryParamsCleaned.replaceAll("prefill", "");
       const queryParamsArray = queryParamsCleaned.split("&") || [];

--- a/src/FormWizard.test.js
+++ b/src/FormWizard.test.js
@@ -6,6 +6,11 @@ import App from "./App";
 import { Route } from "react-router-dom";
 import FormWizard from "./FormWizard";
 
+global.sessionStorage = {
+  getItem: () => undefined,
+  setItem: () => undefined
+};
+
 configure({ adapter: new Adapter() });
 
 const steps = [
@@ -346,6 +351,7 @@ describe("FormWizard", () => {
       });
 
       it("starts at selected step if matching formData is given", async () => {
+        sessionStorage.setItem("test", "me");
         const wrapper = shallow(
           <FormWizard
             formData={{ first_first: "A", second_first: "A" }}


### PR DESCRIPTION
Allow prefilling specific field from url query

`https://example.org?prefill[dummy]=Römergasse%206,%204057%20Basel`

`prefill[<field-uid-from-json>]=<text-to-prefill>`

only works for text or textarea input fields curenlty.